### PR TITLE
feat: Add System Overview screen for Owner

### DIFF
--- a/lib/Controller/owner/financial_controller.dart
+++ b/lib/Controller/owner/financial_controller.dart
@@ -20,8 +20,10 @@ class FinancialController extends ChangeNotifier {
       final revenue = await _service.getTotalRevenue();
       final report = await _service.getMonthlyReport();
 
+
       totalRevenue = revenue;
       monthlyReport = report.map((e) => Expense.fromJson(e as Map<String, dynamic>)).toList();
+      print(monthlyReport);
     } catch (e) {
       debugPrint('❌ Error loading financial data: $e');
     } finally {

--- a/lib/Controller/owner/system_controller.dart
+++ b/lib/Controller/owner/system_controller.dart
@@ -1,0 +1,46 @@
+import 'package:extractorapplication/Model/group_model.dart';
+import 'package:flutter/cupertino.dart';
+
+import '../../Model/user_model.dart';
+import '../../services/owner/system_service.dart';
+
+class SystemController extends ChangeNotifier {
+  final _service = SystemService();
+
+  List<Group> groups = [];
+  List<User> users = [];
+  bool isLoading = false;
+
+  Future<void> loadSystemOverview() async{
+    isLoading = true;
+    notifyListeners();
+
+    try{
+      groups = await _service.getGroups();
+      users = await _service.getUsers();
+    } catch (e) {
+      debugPrint('❌ Error loading system overview: $e');
+    } finally {
+      isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> addUser(String userId, String groupId) async {
+    try {
+      await _service.addUser(userId, groupId);
+      notifyListeners();
+    } catch (e) {
+      debugPrint('❌ Error adding user: $e');
+    }
+  }
+
+  Future<void> removeUserFromGroup(String userId, String groupId) async {
+    try {
+      await _service.removeUserFromGroup(userId, groupId);
+      notifyListeners();
+    } catch (e) {
+      debugPrint('❌ Error removing user from group: $e');
+    }
+  }
+}

--- a/lib/routes/app_route.dart
+++ b/lib/routes/app_route.dart
@@ -16,7 +16,7 @@ class AppRoutes {
     static const String addFinancial = '/add-financial';
     static const String editFinancial = '/edit-financial';
   //system in owner
-    static const String systemLists = '/system-lists';
+    static const String systemLists = '/owner/system/system-overview-view';
     static const String addSystem = '/add-system';
     static const String editSystem = '/edit-system';
 }

--- a/lib/routes/route_generator.dart
+++ b/lib/routes/route_generator.dart
@@ -1,4 +1,5 @@
 import 'package:extractorapplication/views/owner/owner_navigation.dart';
+import 'package:extractorapplication/views/owner/system/system_list_view.dart';
 import 'package:flutter/material.dart';
 
 import '../views/Auth/forgotPassword.dart';
@@ -37,6 +38,9 @@ class RouteGenerator {
         return MaterialPageRoute(builder: (_) => const FinancialOverviewView());
         case AppRoutes.revenueReportView:
         return MaterialPageRoute(builder: (_) => RevenueReportView());
+        case AppRoutes.systemLists:
+        return MaterialPageRoute(builder: (_) => OwnerSystemOverviewView());
+
 
 
         default:

--- a/lib/services/owner/system_service.dart
+++ b/lib/services/owner/system_service.dart
@@ -1,0 +1,45 @@
+import '../../Model/group_model.dart';
+import '../../Model/user_model.dart';
+import '../../supabase/supabase_client.dart';
+
+class SystemService {
+  final _supabase = SupabaseManager.client;
+
+  Future<List<Group>> getGroups() async {
+    try {
+      final response = await _supabase.from('groups').select('*');
+      final data = response as List;
+      return data.map((e) => Group.fromJson(e)).toList();
+    } catch (e) {
+      throw Exception('have a bug: $e');
+    }
+}
+
+  Future<List<User>> getUsers() async {
+    try {
+      final response = await _supabase.from('users').select('*');
+      final data = response as List;
+      return data.map((e) => User.fromJson(e)).toList();
+  } catch (e) {
+      throw Exception('have a bug: $e');
+    }
+  }
+
+  Future<void> addUser(String userId, String groupId) async {
+    try {
+      await _supabase.from('user_groups').insert({
+        'user_id': userId,
+        'group_id': groupId,
+      });
+    } catch (e) {
+      throw Exception('have a bug: $e');
+    }
+  }
+  Future<void> removeUserFromGroup(String userId, String groupId) async {
+    try {
+      await _supabase.from('user_groups').delete().eq('user_id', userId).eq('group_id', groupId);
+      } catch (e) {
+      throw Exception('have a bug: $e');
+    }
+  }
+}

--- a/lib/views/owner/owner_navigation.dart
+++ b/lib/views/owner/owner_navigation.dart
@@ -1,5 +1,6 @@
 import 'package:extractorapplication/views/owner/dashboard/owner_dashboard_view.dart';
 import 'package:extractorapplication/views/owner/financial/financial_ovwerview_view.dart';
+import 'package:extractorapplication/views/owner/system/system_list_view.dart';
 import 'package:extractorapplication/views/owner/user_management/user_list_view.dart';
 import 'package:flutter/material.dart';
 import 'package:path/path.dart';
@@ -18,18 +19,18 @@ class OwnerNavigationShell extends StatefulWidget {
 class _OwnerNavigationShellState extends State<OwnerNavigationShell> {
   String currentRoute = AppRoutes.ownerDashboard;
 
-  final Map<String, Widget> routeToPage =const {
-    AppRoutes.ownerDashboard: OwnerDashboardView(),
-    AppRoutes.userListView: UserListView(),
-    // AppRoutes.systemLists: ,
-    AppRoutes.financialOverviewView: FinancialOverviewView(),
+  final Map<String, Widget> routeToPage ={
+    AppRoutes.ownerDashboard: const OwnerDashboardView(),
+    AppRoutes.userListView: const UserListView(),
+    AppRoutes.financialOverviewView: const FinancialOverviewView(),
+    AppRoutes.systemLists: OwnerSystemOverviewView(),
   };
 
   final Map<String, String> routeToTitle = const {
     AppRoutes.ownerDashboard: '📊 Thống kê tổng quan',
     AppRoutes.userListView: '👥 Quản lý người dùng',
-    // AppRoutes.ownerSystem: '⚙️ Hệ thống',
      AppRoutes.financialOverviewView: '💰 Tài chính',
+    AppRoutes.systemLists: '⚙️ Hệ thống',
   };
 
   void _navigateTo(String route) {
@@ -43,8 +44,8 @@ class _OwnerNavigationShellState extends State<OwnerNavigationShell> {
     final currentIndex = [
       AppRoutes.ownerDashboard,
       AppRoutes.userListView,
-      // AppRoutes.ownerSystem,
       AppRoutes.financialOverviewView,
+      AppRoutes.systemLists,
     ].indexOf(currentRoute);
     return Scaffold(
       appBar: AppBar(title: Text(routeToTitle[currentRoute]??'Khong co tieu de')),
@@ -58,6 +59,7 @@ class _OwnerNavigationShellState extends State<OwnerNavigationShell> {
               AppRoutes.ownerDashboard,
               AppRoutes.userListView,
               AppRoutes.financialOverviewView,
+              AppRoutes.systemLists,
         ][i])),
         type: BottomNavigationBarType.fixed,
         selectedItemColor: AppPallete.gradient1,

--- a/lib/views/owner/system/system_list_view.dart
+++ b/lib/views/owner/system/system_list_view.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../../Controller/owner/system_controller.dart';
+import '../../../utils/date_formatter.dart';
+
+class OwnerSystemOverviewView extends StatelessWidget {
+  final formatDate = DateFormatter();
+  OwnerSystemOverviewView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider(
+      create: (_) => SystemController()..loadSystemOverview(),
+      child: Consumer<SystemController>(
+        builder: (context, controller, _) {
+          if (controller.isLoading) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          return Scaffold(
+            body: Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: SingleChildScrollView(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text('📦 Danh sách nhóm (${controller.groups.length})',
+                        style: Theme.of(context).textTheme.titleMedium),
+                    const SizedBox(height: 8),
+                    ...controller.groups.map((group) => Card(
+                      child: ListTile(
+                        title: Text('🧭 ${group.name ?? 'Nhóm không tên'}'),
+                        subtitle: Text('ID: ${group.id ?? 'Không rõ'}'),
+                      ),
+                    )),
+                    const Divider(height: 32),
+                    Text('👥 Thành viên (${controller.users.length})',
+                        style: Theme.of(context).textTheme.titleMedium),
+                    const SizedBox(height: 8),
+                    ...controller.users.map((user) => Card(
+                      child: ListTile(
+                        leading: const Icon(Icons.person),
+                        title: Text(user.userName ?? 'Không rõ'),
+                        subtitle: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text('📧 Email: ${user.email ?? 'Không rõ'}'),
+                            Text('🛡 Vai trò: ${user.role ?? 'Không rõ'}'),
+                          ],
+                        ),
+                        trailing: const Icon(Icons.chevron_right),
+                        onTap: () {
+                          // TODO: mở chi tiết người dùng hoặc sửa
+                        },
+                      ),
+                    )),
+                  ],
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This commit introduces a new "System Overview" screen for the owner role.

- **Navigation**: Adds a "System" tab to the owner's bottom navigation bar.
- **Routing**: Defines the route and sets up the navigation logic for the new screen.
- **System Screen**: Creates the `OwnerSystemOverviewView` to display a list of groups and users.
- **Controller & Service**: Implements `SystemController` and `SystemService` to fetch group and user data from the backend.