### PR TITLE
feat: Implement remember me and update UI

### DIFF
--- a/lib/Controller/owner/owner_dashboard_controller.dart
+++ b/lib/Controller/owner/owner_dashboard_controller.dart
@@ -1,3 +1,7 @@
+import 'package:flutter/material.dart';
+import 'package:path/path.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../../routes/app_route.dart';
 import '../../services/owner/owner_financial_service.dart';
 import '../../services/owner/owner_system_service.dart';
 import '../../services/owner/owner_user_service.dart';
@@ -24,6 +28,17 @@ class OwnerDashboardController {
     }catch (e) {
       isLoading = false;
       throw Exception('Error loading dashboard data: $e');
+    }
+  }
+
+  Future<void> navigateUser() async {
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    var status = prefs.getBool('isLoggedIn') ?? false;
+    print(status);
+    if (status) {
+      Navigator.pushReplacementNamed(context as BuildContext, AppRoutes.ownerNavigationView);
+    } else {
+      Navigator.pushReplacementNamed(context as BuildContext, AppRoutes.login);
     }
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:extractorapplication/routes/route_generator.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'core/secrets/app_secrets.dart';
@@ -17,12 +18,16 @@ void main() async {
     anonKey: AppSecrets.supabaseAnonkey,
   );
 
-  runApp(const MyApp());
+  SharedPreferences prefs = await SharedPreferences.getInstance();
+  var status =  prefs.getBool('isLoggedIn') ?? false;
+  print(status);
+  runApp(MyApp(isLoggedIn: status));
 }
 
 
 class MyApp extends StatelessWidget{
-  const MyApp({super.key});
+  final bool isLoggedIn;
+  const MyApp({super.key, required this.isLoggedIn});
 
   @override
   Widget build(BuildContext context) {
@@ -30,7 +35,7 @@ class MyApp extends StatelessWidget{
       debugShowCheckedModeBanner: false,
       title: 'Quản lý chi tiêu',
       theme: AppTheme.darkThemeMode,
-      initialRoute: AppRoutes.login,
+      initialRoute: isLoggedIn ? AppRoutes.ownerNavigationView : AppRoutes.login,
       onGenerateRoute: RouteGenerator.generateRoute,
     );
   }

--- a/lib/views/owner/dashboard/owner_dashboard_view.dart
+++ b/lib/views/owner/dashboard/owner_dashboard_view.dart
@@ -26,9 +26,11 @@ class _OwnerDashboardViewState extends State<OwnerDashboardView> {
   @override
   void initState() {
     super.initState();
-    if(mounted) {
-      controller.loadDashboardData().then((_) => setState(() {}));
-    }
+    controller.loadDashboardData().then((_) {
+      if(mounted) {
+        setState(() {});
+      }
+    });
   }
 
   @override

--- a/lib/views/owner/user_management/user_list_view.dart
+++ b/lib/views/owner/user_management/user_list_view.dart
@@ -35,23 +35,40 @@ class _UserListViewState extends State<UserListView> {
             itemCount: controller.users.length,
             itemBuilder: (context, index) {
               final user = controller.users[index];
-              return ListTile(
-                  leading: const CircleAvatar(child: Icon(Icons.person)),
-                  title: Text(user.fullName ?? 'Không rõ'),
-                  subtitle: Text(
-                      '${user.email ?? 'Không rõ'} - ${user.role ??
-                          'Không rõ'}'),
-                onTap: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => UserDetailView(
-                        user: user,
-                        formatDate: formatDate,
-                      ),
+              return Card(
+                elevation: 2,
+                margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: ListTile(
+                    contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                    leading: const CircleAvatar(
+                        backgroundColor: AppPallete.backgroundColor,
+                        child: Icon(Icons.person)
                     ),
-                  );
-                },
+                  title: Text(
+                    user.fullName ?? 'Không rõ',
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  subtitle: Text(
+                    '${user.email ?? 'Không rõ'} • ${user.role ?? 'Không rõ'}',
+                    style: TextStyle(color: Colors.grey[700]),
+                  ),
+                  trailing: const Icon(Icons.arrow_forward_ios, size: 16),
+
+                  onTap: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => UserDetailView(
+                          user: user,
+                          formatDate: formatDate,
+                        ),
+                      ),
+                    );
+                  },
+                ),
               );
             },
         ),

--- a/lib/views/shared/splash_screen.dart
+++ b/lib/views/shared/splash_screen.dart
@@ -1,4 +1,5 @@
-
+import 'dart:async';
+import 'package:extractorapplication/Controller/owner/owner_dashboard_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -14,11 +15,27 @@ class SplashScreen extends StatefulWidget {
 }
 
 class _SplashScreenState extends State<SplashScreen> {
+  final OwnerDashboardController controller = OwnerDashboardController();
+
+  @override
+  void dispose() {
+    super.dispose();
+    controller.dispose();
+  }
+
   @override
   void initState() {
     super.initState();
+    startTimer();
     _initializeApp();
   }
+
+  void startTimer() {
+    Timer(Duration(seconds: 3), () {
+      controller.navigateUser(); //It will redirect  after 3 seconds
+    });
+  }
+
 
   Future<void> _initializeApp() async {
     try {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:extractorapplication/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(MyApp());
+    await tester.pumpWidget(MyApp(isLoggedIn: true,));
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
- Implement "Remember Me" functionality using SharedPreferences to keep users logged in.
- Update the app's initial route based on the user's login status.
- Add a splash screen with a 3-second timer that navigates the user appropriately.
- Enhance the UI for the user list view with Cards and improved styling.
- Refactor `initState` in `owner_dashboard_view` to ensure `setState` is called only when the component is mounted.