### PR TITLE
Fix: Reorder imports in `auth_controller.dart`

### DIFF
--- a/lib/Controller/auth_controller.dart
+++ b/lib/Controller/auth_controller.dart
@@ -1,6 +1,6 @@
-import 'package:extractorapplication/Controller/base_controller.dart';
 import '../core/exception/login_exception.dart';
 import '../core/services/auth_service.dart';
+import 'base_controller.dart';
 
 ///tao helper der gom logic chung
 ///auth cho cac view


### PR DESCRIPTION
The import for `base_controller.dart` is moved to be after the imports for core services to maintain a consistent import order.