### PR TITLE
feat: Implement CRUD for notes and enhance expense/revenue forms

### DIFF
--- a/lib/Controller/owner/note_management_controller.dart
+++ b/lib/Controller/owner/note_management_controller.dart
@@ -1,5 +1,6 @@
 import 'package:extractorapplication/Controller/base_controller.dart';
 import 'package:flutter/cupertino.dart';
+
 import '../../Model/note_model.dart';
 import '../../core/services/owner/owner_note_service.dart';
 
@@ -8,6 +9,7 @@ class NoteManagementController extends BaseController {
   NoteManagementController(this._service);
 
   List<Note> notes = [];
+  String? errorMessage;
 
   Future<void> _fetchData() async {
     notes = await _service.getAllNotes();
@@ -17,24 +19,58 @@ class NoteManagementController extends BaseController {
     await loadData(_fetchData);
   }
 
-  Future<bool> _performAction(Future<void> Function() action) async {
+  Future<void> addNote(Map<String, dynamic> noteData) async {
     setLoading(true);
+    errorMessage = null;
     try {
-      await action();
-      return true;
+      final newNote = await _service.createNote(noteData);
+      notes.insert(0, newNote);
+      notifyListeners();
     } catch (e) {
-      debugPrint('NoteManagementController Error: $e');
-      return false;
+      errorMessage = e.toString();
+      debugPrint('NoteManagementController Error creating note: $e');
     } finally {
       setLoading(false);
     }
   }
 
-  Future<void> addNote(Map<String, dynamic> noteData) async {
-    await _performAction(() async {
-      final newNote = await _service.createNote(noteData);
-      notes.insert(0, newNote);
+  Future<bool> updateNote(Note noteToUpdate) async {
+    setLoading(true);
+    errorMessage = null;
+    try {
+      final updatedNote = await _service.updateNote(noteToUpdate);
+
+      final index = notes.indexWhere((note) => note.id == updatedNote.id);
+
+      if (index != -1) {
+        notes[index] = updatedNote;
+      }
+
       notifyListeners();
-    });
+      setLoading(false);
+      return true;
+    } catch (e) {
+      errorMessage = e.toString();
+      debugPrint('NoteManagementController Error updating note: $e');
+      setLoading(false);
+      return false;
+    }
+  }
+
+  Future<bool> deleteNote(int noteId) async {
+    setLoading(true);
+    errorMessage = null;
+    try {
+      await _service.deleteNote(noteId);
+      notes.removeWhere((note) => note.id == noteId);
+      notifyListeners();
+      setLoading(false);
+      return true;
+    } catch (e) {
+      errorMessage = e.toString();
+      debugPrint('NoteManagementController Error deleting note: $e');
+      setLoading(false);
+      return false;
+    }
   }
 }

--- a/lib/Model/expense_model.dart
+++ b/lib/Model/expense_model.dart
@@ -5,6 +5,7 @@ class Expense {
   final double amount;
   final String? description;
   final DateTime createdAt;
+  final String category;
 
   Expense({
     required this.id,
@@ -13,6 +14,7 @@ class Expense {
     required this.amount,
     this.description,
     required this.createdAt,
+    required this.category,
   });
 
   factory Expense.fromJson(Map<String, dynamic> json) {
@@ -23,16 +25,18 @@ class Expense {
       amount: (json['amount'] as num).toDouble(),
       description: json['description'] as String?,
       createdAt: DateTime.parse(json['created_at'] as String),
+      category: json['category'] as String,
     );
   }
 
-
-  Map<String, dynamic> toJson(){
+  Map<String, dynamic> toJson() {
     return {
       'group_id': groupId,
       'user_id': userId,
       'amount': amount,
       'description': description,
+      'created_at': createdAt.toIso8601String(),
+      'category': category,
     };
   }
 
@@ -43,6 +47,7 @@ class Expense {
     double? amount,
     String? description,
     DateTime? createdAt,
+    String? category,
   }) {
     return Expense(
       id: id ?? this.id,
@@ -51,6 +56,7 @@ class Expense {
       amount: amount ?? this.amount,
       description: description ?? this.description,
       createdAt: createdAt ?? this.createdAt,
+      category: category ?? this.category,
     );
   }
 }

--- a/lib/Model/note_model.dart
+++ b/lib/Model/note_model.dart
@@ -1,71 +1,57 @@
-// G:/Project/Breakfast-Store-Expense-Tracker/lib/Model/note_model.dart.
+// G:/Project/Breakfast-Store-Expense-Tracker/lib/Model/note_model.dart
 
 class Note {
   final int id;
   final String userId;
   final String? title;
   final String content;
-  // SỬA ĐỔI 1: Giả sử category và priority trong CSDL là số (int)
-  final int category;
-  final int priority;
-  final bool isCompleted;
   final DateTime createdAt;
   final DateTime updatedAt;
 
   Note({
     required this.id,
     required this.userId,
-    this.title, // `title` có thể null nên không cần `required`
+    this.title,
     required this.content,
-    required this.category,
-    required this.priority,
-    required this.isCompleted,
     required this.createdAt,
     required this.updatedAt,
   });
 
-  // Updated to use snake_case for Supabase compatibility
   factory Note.fromJson(Map<String, dynamic> json) {
     return Note(
       id: json['id'] as int,
       userId: json['user_id'] as String,
-
-      // SỬA ĐỔI 2: Xử lý an toàn cho các trường có thể null
-      title: json['title'] as String?, // Cho phép giá trị null
-      content: json['content'] as String? ??
-          '', // Nếu content là null, trả về chuỗi rỗng
-
-      // SỬA ĐỔI 3 (QUAN TRỌNG NHẤT): Sửa kiểu dữ liệu để khớp với CSDL
-      // Ép kiểu 'category' và 'priority' thành int, nếu null thì gán giá trị mặc định (ví dụ: 0)
-      category: json['category'] as int? ?? 0,
-      priority: json['priority'] as int? ?? 0,
-
-      isCompleted:
-          json['is_completed'] as bool? ?? false, // Xử lý an toàn cho bool
-
-      // Xử lý an toàn cho DateTime, phòng trường hợp CSDL trả về null
-      createdAt: json['created_at'] != null
-          ? DateTime.parse(json['created_at'] as String)
-          : DateTime.now(),
-      updatedAt: json['updated_at'] != null
-          ? DateTime.parse(json['updated_at'] as String)
-          : DateTime.now(),
+      title: json['title'] as String?,
+      content: json['content'] as String? ?? '',
+      createdAt: DateTime.parse(json['created_at'] as String),
+      updatedAt: DateTime.parse(json['updated_at'] as String),
     );
   }
 
-  // Phương thức toJson không cần sửa nếu bạn không có ý định gửi category/priority dạng số lên server
-  // Nhưng để đồng bộ, nên sửa cả toJson
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
       'user_id': userId,
       'title': title,
       'content': content,
-      'category': category, // Gửi đi dưới dạng int
-      'priority': priority, // Gửi đi dưới dạng int
-      'is_completed': isCompleted,
-      'created_at': createdAt.toIso8601String(),
       'updated_at': updatedAt.toIso8601String(),
     };
+  }
+
+  Note copyWith({
+    int? id,
+    String? userId,
+    String? title,
+    String? content,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return Note(
+      id: id ?? this.id,
+      userId: userId ?? this.userId,
+      title: title ?? this.title,
+      content: content ?? this.content,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
   }
 }

--- a/lib/core/services/owner/owner_note_service.dart
+++ b/lib/core/services/owner/owner_note_service.dart
@@ -10,6 +10,7 @@ class OwnerNoteService {
   /// Creates a new note record in the database.
   Future<Note> createNote(Map<String, dynamic> noteData) async {
     try {
+      // Giả sử db.insert trả về một Map của bản ghi vừa được tạo
       final responseData = await db.insert('notes', noteData);
       return Note.fromJson(responseData);
     } catch (e) {
@@ -24,6 +25,37 @@ class OwnerNoteService {
       return response.map((e) => Note.fromJson(e)).toList();
     } catch (e) {
       throw ServerException('Error fetching notes: $e');
+    }
+  }
+
+  // ================== BƯỚC 1: THÊM HÀM `updateNote` ==================
+  /// Updates an existing note in the database.
+  ///
+  /// - `note`: Đối tượng Note chứa thông tin mới.
+  ///           Hàm `toJson()` của nó sẽ được dùng để lấy dữ liệu cập nhật.
+  Future<Note> updateNote(Note note) async {
+    try {
+      // Giả sử hàm `db.update` nhận vào (tên bảng, id của bản ghi, dữ liệu Map để cập nhật).
+      // Hàm `note.toJson()` sẽ chuyển đổi đối tượng Note thành một Map<String, dynamic>
+      // với các khóa `snake_case` khớp với tên cột trong CSDL.
+      final responseData = await db.update('notes', note.id, note.toJson());
+
+      // Supabase thường trả về bản ghi đã được cập nhật,
+      // chúng ta chuyển nó lại thành đối tượng Note.
+      return Note.fromJson(responseData);
+    } catch (e) {
+      throw ServerException('Error updating note: $e');
+    }
+  }
+
+  // ================== BƯỚC 2: THÊM HÀM `deleteNote` ==================
+  /// Deletes a note from the database by its ID.
+  Future<void> deleteNote(int noteId) async {
+    try {
+      // Giả sử hàm `db.delete` nhận vào (tên bảng, id của bản ghi cần xóa).
+      await db.delete('notes', noteId);
+    } catch (e) {
+      throw ServerException('Error deleting note: $e');
     }
   }
 }

--- a/lib/views/owner/dashboard/widgets/recent_activity.dart
+++ b/lib/views/owner/dashboard/widgets/recent_activity.dart
@@ -1,10 +1,12 @@
 // G:/Project/Breakfast-Store-Expense-Tracker/lib/views/owner/dashboard/widgets/recent_notes_view.dart
 
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
+import '../../../../../Controller/owner/note_management_controller.dart';
 import '../../../../../Model/note_model.dart';
+import '../../edit_note.dart';
 
-// Tên widget `RecentNotesView` đã rất phù hợp.
 class RecentNotesView extends StatelessWidget {
   final List<Note> notes;
 
@@ -12,8 +14,8 @@ class RecentNotesView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Sử dụng ListView.builder để tối ưu hiệu suất nếu danh sách ghi chú rất dài.
-    // Dùng Column nếu bạn chắc chắn danh sách luôn ngắn.
+    final controller = context.read<NoteManagementController>();
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -22,8 +24,6 @@ class RecentNotesView extends StatelessWidget {
           style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
         ),
         const SizedBox(height: 8),
-
-        // Xử lý trường hợp không có ghi chú nào.
         if (notes.isEmpty)
           const Padding(
             padding: EdgeInsets.symmetric(vertical: 16.0),
@@ -35,53 +35,84 @@ class RecentNotesView extends StatelessWidget {
               ),
             ),
           )
-        // Nếu có ghi chú, hiển thị chúng.
         else
-          // Bọc trong ListView để tránh lỗi tràn màn hình nếu có nhiều ghi chú.
-          // `shrinkWrap: true` và `physics` để nó hoạt động bên trong một `SingleChildScrollView` khác.
           ListView.builder(
             shrinkWrap: true,
             physics: const NeverScrollableScrollPhysics(),
             itemCount: notes.length,
             itemBuilder: (context, index) {
               final note = notes[index];
-
-              // === SỬA ĐỔI CHÍNH NẰM Ở ĐÂY: Dùng Card và ListTile ===
-              // Thay vì dùng Text, chúng ta dùng Card để tạo ra một "bảng nhỏ" cho mỗi ghi chú.
               return Card(
                 margin: const EdgeInsets.only(bottom: 10.0),
-                elevation: 2.0, // Thêm một chút bóng đổ cho đẹp.
+                elevation: 2.0,
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(8.0),
                 ),
                 child: ListTile(
-                  // Biểu tượng ở đầu dòng.
                   leading: Icon(
                     Icons.note_alt_outlined,
                     color: Theme.of(context).primaryColor,
                   ),
-
-                  // Tiêu đề của ghi chú.
-                  // Dùng `note.title ?? 'Không có tiêu đề'` để xử lý trường hợp title là null.
                   title: Text(
                     note.title ?? 'Không có tiêu đề',
                     style: const TextStyle(fontWeight: FontWeight.bold),
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                   ),
-
-                  // Nội dung của ghi chú.
                   subtitle: Text(
                     note.content,
-                    maxLines: 2, // Giới hạn 2 dòng để không bị quá dài.
+                    maxLines: 2,
                     overflow: TextOverflow.ellipsis,
                   ),
-
-                  // Bạn có thể thêm hành động khi nhấn vào, ví dụ:
-                  onTap: () {
-                    // Hiện tại chỉ in ra console, sau này bạn có thể điều hướng đến trang chi tiết ghi chú.
-                    debugPrint('Tapped on note with id: ${note.id}');
-                  },
+                  trailing: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      IconButton(
+                        icon:
+                            const Icon(Icons.edit_outlined, color: Colors.blue),
+                        onPressed: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) => EditNoteView(note: note),
+                            ),
+                          );
+                        },
+                      ),
+                      IconButton(
+                        icon:
+                            const Icon(Icons.delete_outline, color: Colors.red),
+                        onPressed: () {
+                          showDialog(
+                            context: context,
+                            builder: (BuildContext dialogContext) {
+                              return AlertDialog(
+                                title: const Text('Xác nhận xóa'),
+                                content: Text(
+                                    'Bạn có chắc chắn muốn xóa ghi chú "${note.title ?? 'này'}" không?'),
+                                actions: <Widget>[
+                                  TextButton(
+                                    child: const Text('Hủy'),
+                                    onPressed: () {
+                                      Navigator.of(dialogContext).pop();
+                                    },
+                                  ),
+                                  TextButton(
+                                    child: const Text('Xóa',
+                                        style: TextStyle(color: Colors.red)),
+                                    onPressed: () {
+                                      Navigator.of(dialogContext).pop();
+                                      controller.deleteNote(note.id);
+                                    },
+                                  ),
+                                ],
+                              );
+                            },
+                          );
+                        },
+                      ),
+                    ],
+                  ),
                 ),
               );
             },

--- a/lib/views/owner/edit_note.dart
+++ b/lib/views/owner/edit_note.dart
@@ -1,0 +1,138 @@
+// G:/Project/Breakfast-Store-Expense-Tracker/lib/views/owner/note/edit_note_view.dart
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../../../Controller/owner/note_management_controller.dart';
+import '../../../../Model/note_model.dart';
+
+class EditNoteView extends StatefulWidget {
+  // Widget này nhận vào đối tượng `Note` cần được chỉnh sửa.
+  final Note note;
+
+  const EditNoteView({super.key, required this.note});
+
+  @override
+  State<EditNoteView> createState() => _EditNoteViewState();
+}
+
+class _EditNoteViewState extends State<EditNoteView> {
+  final _formKey = GlobalKey<FormState>();
+
+  // Khai báo các TextEditingController để quản lý dữ liệu trên form.
+  late final TextEditingController _titleController;
+  late final TextEditingController _contentController;
+  // Bạn có thể thêm các controller cho category, priority nếu muốn chúng cũng có thể được sửa.
+
+  // `initState` được gọi một lần khi widget được tạo.
+  // Chúng ta dùng nó để điền dữ liệu có sẵn của `note` vào các controller.
+  @override
+  void initState() {
+    super.initState();
+    _titleController = TextEditingController(text: widget.note.title);
+    _contentController = TextEditingController(text: widget.note.content);
+  }
+
+  // `dispose` được gọi khi widget bị hủy.
+  // Rất quan trọng để giải phóng bộ nhớ cho các controller.
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _contentController.dispose();
+    super.dispose();
+  }
+
+  /// Hàm này được gọi khi người dùng nhấn nút "Lưu Thay Đổi".
+  void _submitChanges() async {
+    // 1. Kiểm tra xem form có hợp lệ không.
+    if (_formKey.currentState?.validate() != true) {
+      return;
+    }
+
+    // 2. Lấy controller từ Provider.
+    final controller = context.read<NoteManagementController>();
+
+    // 3. Tạo một đối tượng `Note` mới với các thông tin đã được cập nhật từ form.
+    // Sử dụng `copyWith` để giữ lại các trường không thay đổi như `id`, `userId`, `createdAt`,...
+    final updatedNote = widget.note.copyWith(
+      title: _titleController.text.trim(),
+      content: _contentController.text.trim(),
+      // Gán lại updatedAt thành thời gian hiện tại.
+      updatedAt: DateTime.now(),
+    );
+
+    // 4. Gọi hàm `updateNote` từ controller.
+    final success = await controller.updateNote(updatedNote);
+    if (!mounted) return;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Lắng nghe trạng thái `isLoading` từ controller để vô hiệu hóa nút bấm khi cần.
+    final isLoading = context.watch<NoteManagementController>().isLoading;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Sửa Ghi Chú'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Form(
+          key: _formKey,
+          child: ListView(
+            children: [
+              TextFormField(
+                controller: _titleController,
+                decoration: const InputDecoration(
+                  labelText: 'Tiêu đề',
+                  border: OutlineInputBorder(),
+                  prefixIcon: Icon(Icons.title),
+                ),
+                validator: (value) {
+                  // Mặc dù title có thể null, ta vẫn có thể yêu cầu người dùng không để trống khi sửa.
+                  if (value == null || value.trim().isEmpty) {
+                    return 'Vui lòng nhập tiêu đề';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _contentController,
+                decoration: const InputDecoration(
+                  labelText: 'Nội dung',
+                  border: OutlineInputBorder(),
+                  prefixIcon: Icon(Icons.text_fields),
+                  alignLabelWithHint:
+                      true, // Căn chỉnh label lên trên khi có nhiều dòng.
+                ),
+                maxLines: 8, // Cho phép nhập nhiều dòng hơn cho nội dung.
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'Vui lòng nhập nội dung';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 24),
+              ElevatedButton.icon(
+                onPressed: isLoading ? null : _submitChanges,
+                style: ElevatedButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                  backgroundColor:
+                      Colors.blue, // Màu sắc cho hành động cập nhật.
+                ),
+                icon: isLoading
+                    ? Container() // Ẩn icon khi đang loading
+                    : const Icon(Icons.save_as_outlined),
+                label: isLoading
+                    ? const CircularProgressIndicator(color: Colors.white)
+                    : const Text('Lưu Thay Đổi'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/owner/financial/add_revenue_view.dart
+++ b/lib/views/owner/financial/add_revenue_view.dart
@@ -1,8 +1,10 @@
 import 'package:extractorapplication/Controller/owner/financial_controller.dart';
+import 'package:extractorapplication/Controller/owner/system_controller.dart';
+import 'package:extractorapplication/Model/group_model.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
-import 'package:supabase_flutter/supabase_flutter.dart'; // Correctly added import
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 class AddRevenueView extends StatefulWidget {
   const AddRevenueView({super.key});
@@ -16,6 +18,22 @@ class _AddRevenueViewState extends State<AddRevenueView> {
   final _amountController = TextEditingController();
   final _descriptionController = TextEditingController();
   DateTime _selectedDate = DateTime.now();
+
+  // Biến state để lưu các giá trị được chọn từ form
+  String? _selectedCategory;
+  // BƯỚC 1: THÊM BIẾN ĐỂ LƯU TRỮ GROUP ĐÃ CHỌN
+  int? _selectedGroupId; // ID của group là kiểu int
+
+  @override
+  void initState() {
+    super.initState();
+    // Ngay khi màn hình được tạo, yêu cầu SystemController tải danh sách nhóm.
+    // Dùng addPostFrameCallback để đảm bảo việc gọi không xảy ra trong lúc build.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      // Đảm bảo SystemController đã được cung cấp ở cây widget cha.
+      context.read<SystemController>().loadSystemOverview();
+    });
+  }
 
   @override
   void dispose() {
@@ -39,6 +57,7 @@ class _AddRevenueViewState extends State<AddRevenueView> {
   }
 
   void _saveRevenue() async {
+    // Kích hoạt validation và kiểm tra form
     if (_formKey.currentState?.validate() != true) {
       return;
     }
@@ -49,32 +68,35 @@ class _AddRevenueViewState extends State<AddRevenueView> {
     if (userId == null) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
-            content: Text('Lỗi: Không tìm thấy người dùng hiện tại.')),
+            backgroundColor: Colors.red,
+            content:
+                Text('Lỗi nghiêm trọng: Không tìm thấy người dùng hiện tại.')),
       );
       return;
     }
 
-    // Simplified data payload to only send what's necessary.
-    // The database should handle defaults for other columns.
+    // BƯỚC 2: CẬP NHẬT DỮ LIỆU GỬI ĐI, THÊM 'group_id' VÀO MAP
     final expenseData = {
       'user_id': userId,
       'amount': double.parse(_amountController.text),
       'description': _descriptionController.text,
+      'category': _selectedCategory,
+      'group_id': _selectedGroupId, // << Thêm giá trị group_id đã chọn
       'created_at': _selectedDate.toIso8601String(),
     };
 
-    await controller.addRevenue(expenseData);
+    // Gọi hàm `addRevenue` và kiểm tra kết quả trả về
+    final success = await controller.addRevenue(expenseData);
 
-    if (mounted) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('Đã lưu doanh thu!')));
-      Navigator.pop(context);
-    }
+    // Chỉ thực hiện các hành động tiếp theo nếu widget vẫn còn trên cây UI
+    if (!mounted) return;
   }
 
   @override
   Widget build(BuildContext context) {
-    final isLoading = context.watch<FinancialController>().isLoading;
+    // Lắng nghe trạng thái từ cả hai controller
+    final financialController = context.watch<FinancialController>();
+    final systemController = context.watch<SystemController>();
 
     return Scaffold(
       appBar: AppBar(
@@ -99,29 +121,90 @@ class _AddRevenueViewState extends State<AddRevenueView> {
                   if (value == null || value.isEmpty) {
                     return 'Vui lòng nhập số tiền';
                   }
-                  if (double.tryParse(value) == null) {
+                  final amount = double.tryParse(value);
+                  if (amount == null) {
                     return 'Vui lòng nhập một số hợp lệ';
+                  }
+                  if (amount <= 0) {
+                    return 'Số tiền phải lớn hơn 0';
                   }
                   return null;
                 },
               ),
               const SizedBox(height: 16),
+
+              // BƯỚC 3: THÊM WIDGET DROPDOWN ĐỂ CHỌN NHÓM
+              DropdownButtonFormField<int>(
+                value: _selectedGroupId,
+                decoration: const InputDecoration(
+                  labelText: 'Nhóm',
+                  border: OutlineInputBorder(),
+                  prefixIcon: Icon(Icons.group_work_outlined),
+                ),
+                hint: const Text('Chọn nhóm liên quan'),
+                // Dữ liệu được lấy từ SystemController,
+                // hiển thị loading nếu chưa có dữ liệu nhóm
+                items: systemController.isLoading
+                    ? []
+                    : systemController.groups.map((Group group) {
+                        return DropdownMenuItem<int>(
+                          value: group.id, // Giá trị là ID của nhóm (int)
+                          child: Text(group.name), // Hiển thị là tên nhóm
+                        );
+                      }).toList(),
+                onChanged: (value) {
+                  setState(() {
+                    _selectedGroupId = value;
+                  });
+                },
+                // Bắt buộc người dùng phải chọn một nhóm
+                validator: (value) =>
+                    value == null ? 'Vui lòng chọn một nhóm' : null,
+              ),
+
+              const SizedBox(height: 16),
+
+              // Widget dropdown để chọn danh mục (đã có từ trước)
+              DropdownButtonFormField<String>(
+                value: _selectedCategory,
+                decoration: const InputDecoration(
+                  labelText: 'Danh mục',
+                  border: OutlineInputBorder(),
+                  prefixIcon: Icon(Icons.category_outlined),
+                ),
+                hint: const Text('Chọn một danh mục'),
+                items: const [
+                  DropdownMenuItem(
+                      value: 'Bán tại chỗ', child: Text('Bán tại chỗ')),
+                  DropdownMenuItem(value: 'Mang đi', child: Text('Mang đi')),
+                  DropdownMenuItem(
+                      value: 'Giao hàng', child: Text('Giao hàng')),
+                  DropdownMenuItem(value: 'Khác', child: Text('Khác')),
+                ],
+                onChanged: (value) {
+                  setState(() {
+                    _selectedCategory = value;
+                  });
+                },
+                validator: (value) => value == null || value.isEmpty
+                    ? 'Vui lòng chọn một danh mục'
+                    : null,
+              ),
+
+              const SizedBox(height: 16),
+
               TextFormField(
                 controller: _descriptionController,
                 decoration: const InputDecoration(
-                  labelText: 'Mô tả',
+                  labelText: 'Mô tả (Ghi chú)',
                   border: OutlineInputBorder(),
                   hintText: 'Nhập mô tả cho khoản thu',
                 ),
                 maxLines: 3,
-                validator: (value) {
-                  if (value == null || value.isEmpty) {
-                    return 'Vui lòng nhập mô tả';
-                  }
-                  return null;
-                },
+                // Ghi chú là tùy chọn, không cần validator
               ),
               const SizedBox(height: 16),
+
               Row(
                 children: [
                   Expanded(
@@ -138,14 +221,18 @@ class _AddRevenueViewState extends State<AddRevenueView> {
               const SizedBox(height: 24),
               SizedBox(
                 width: double.infinity,
-                child: ElevatedButton(
-                  onPressed: isLoading ? null : _saveRevenue,
+                child: ElevatedButton.icon(
+                  onPressed:
+                      financialController.isLoading ? null : _saveRevenue,
                   style: ElevatedButton.styleFrom(
                     padding: const EdgeInsets.symmetric(vertical: 16),
                   ),
-                  child: isLoading
+                  icon: financialController.isLoading
+                      ? Container()
+                      : const Icon(Icons.save),
+                  label: financialController.isLoading
                       ? const CircularProgressIndicator(color: Colors.white)
-                      : const Text('Lưu doanh thu'),
+                      : const Text('Lưu Doanh Thu'),
                 ),
               ),
             ],


### PR DESCRIPTION
This commit introduces full CRUD (Create, Read, Update, Delete) functionality for notes and improves the data entry forms for revenues and expenses.

- **Note Management (CRUD):**
    - Adds `updateNote` and `deleteNote` methods to `OwnerNoteService` to interact with the database.
    - Implements `updateNote` and `deleteNote` logic in `NoteManagementController`, including state management for UI updates.
    - Creates a new `EditNoteView` screen to allow users to modify existing notes.
    - Adds "Edit" and "Delete" buttons to the `RecentNotesView` on the dashboard, with a confirmation dialog for deletion.
    - Refactors `Note` model to simplify fields and add a `copyWith` method.

- **Expense & Revenue Forms:**
    - Adds a mandatory `category` field to the `Expense` model and the `AddRevenueView` form.
    - Integrates a `group` selection dropdown in `AddRevenueView`, requiring users to associate each revenue entry with a group.
    - Enhances form validation in `AddRevenueView` for amount, category, and group fields.