### PR TITLE
refactor: Clean up code and enhance dashboard/financial views

### DIFF
--- a/lib/Controller/owner/financial_controller.dart
+++ b/lib/Controller/owner/financial_controller.dart
@@ -1,8 +1,12 @@
 import 'package:extractorapplication/Controller/base_controller.dart';
 import 'package:flutter/cupertino.dart';
+
 import '../../Model/expense_model.dart';
 import '../../core/services/owner/owner_financial_service.dart';
 
+///lop controller thuc hien xu ly logic
+///goi service tuong ung de xu ly du lieu ben tren va ben duoi
+///lop nay giup toi uu viec xu ly thay vi lap lai qua trinh goi nhieu lan tu cac lop
 class FinancialController extends BaseController {
   final OwnerFinancialService _service;
   //nhan service thong quan constructor

--- a/lib/Controller/owner/owner_dashboard_controller.dart
+++ b/lib/Controller/owner/owner_dashboard_controller.dart
@@ -15,71 +15,54 @@ class OwnerDashboardController extends BaseController {
   final OwnerUserService _userService;
   final OwnerFinancialService _financialService;
   final OwnerSystemService _systemService;
-
-  // === BƯỚC 2: THÊM NOTE SERVICE VÀO CONSTRUCTOR ===
   final OwnerNoteService _noteService;
 
   OwnerDashboardController(
     this._userService,
     this._financialService,
     this._systemService,
-    this._noteService, // Thêm service vào đây
+    this._noteService,
   );
 
   int totalUsers = 0;
   double totalRevenue = 0.0;
   String systemHealth = 'Checking...';
-
-  // === BƯỚC 3: THAY ĐỔI THUỘC TÍNH ĐỂ LƯU DANH SÁCH NOTE ===
-  // Xóa thuộc tính cũ
-  // List<String> recentActivities = [];
-  // Thêm thuộc tính mới
   List<Note> recentNotes = [];
 
   Future<void> _fetchData() async {
-    // === BƯỚC 4: CẬP NHẬT HÀM ĐỂ LẤY DỮ LIỆU NOTE ===
     try {
       final result = await Future.wait([
         _userService.getUserCount(),
         _financialService.getTotalRevenue(),
         _systemService.getSystemHealth(),
-        // Gọi hàm lấy danh sách ghi chú thay vì "hoạt động"
         _noteService.getAllNotes(),
       ]);
 
-      // Ép kiểu và gán dữ liệu vào các thuộc tính tương ứng
       totalUsers = result[0] as int;
       totalRevenue = result[1] as double;
       systemHealth = result[2] as String;
-      // Gán kết quả vào thuộc tính mới `recentNotes`
       recentNotes = result[3] as List<Note>;
     } catch (e) {
       debugPrint('Error fetching dashboard data in controller: $e');
-      rethrow; // Ném lại lỗi để BaseController có thể xử lý
+      rethrow;
     }
   }
 
   Future<void> loadDashboardData() async {
-    // Hàm loadData trong BaseController sẽ tự động quản lý isLoading và lỗi
     await loadData(_fetchData);
   }
 
-  // Hàm navigateUser không liên quan đến việc hiển thị dữ liệu nên không cần sửa.
-  // Tuy nhiên, việc sử dụng `context as BuildContext` là không an toàn.
-  // Tốt hơn là nên truyền BuildContext vào làm tham số.
   Future<void> navigateUser(BuildContext context) async {
     try {
       SharedPreferences prefs = await SharedPreferences.getInstance();
       var status = prefs.getBool('isLoggedIn') ?? false;
       if (status) {
-        // Sử dụng context được truyền vào một cách an toàn
         Navigator.pushReplacementNamed(context, AppRoutes.ownerNavigationView);
       } else {
         Navigator.pushReplacementNamed(context, AppRoutes.login);
       }
     } catch (e) {
       debugPrint('Error navigating user: $e');
-      // Không nên ném Exception ở đây vì nó có thể làm sập ứng dụng nếu không được bắt
     }
   }
 }

--- a/lib/Controller/owner/system_controller.dart
+++ b/lib/Controller/owner/system_controller.dart
@@ -5,7 +5,6 @@ import '../../Model/user_model.dart';
 import '../../core/services/owner/system_service.dart';
 import '../base_controller.dart';
 
-/// Controller sử dụng Provider để lắng nghe, quản lý dữ liệu hệ thống (nhóm, người dùng).
 class SystemController extends BaseController {
   final SystemService _service;
   SystemController(this._service);
@@ -13,36 +12,28 @@ class SystemController extends BaseController {
   List<Group> groups = [];
   List<User> users = [];
 
-  // === SỬA LỖI 1: Thay đổi kiểu dữ liệu của key từ String sang int ===
   Map<int, List<User>> groupMembers = {};
   Set<int> loadingGroups = {};
 
   Future<void> _fetchData() async {
     try {
-      // Gọi song song để tăng tốc độ
       final results = await Future.wait([
         _service.getGroups(),
         _service.getUsers(),
       ]);
 
-      // === SỬA LỖI 2: Ép kiểu an toàn hơn ===
-      // Kết quả của Future.wait là List<dynamic>, cần ép kiểu từng phần tử
       groups = results[0] as List<Group>;
       users = results[1] as List<User>;
     } catch (e) {
-      // Ném lại lỗi để hàm loadData có thể bắt và xử lý
       debugPrint('Lỗi nghiêm trọng khi fetch data hệ thống: $e');
       rethrow;
     }
   }
 
-  /// Tải dữ liệu tổng quan của hệ thống (danh sách nhóm và người dùng).
   Future<void> loadSystemOverview() async {
-    // Sử dụng hàm loadData từ BaseController để quản lý trạng thái isLoading và error
     await loadData(_fetchData);
   }
 
-  // Hàm tiện ích để thực hiện hành động và quản lý trạng thái loading
   Future<bool> _performAction(Future<void> Function() action) async {
     setLoading(true);
     try {
@@ -56,31 +47,24 @@ class SystemController extends BaseController {
     }
   }
 
-  // === SỬA LỖI 1: Thay đổi kiểu dữ liệu của groupId từ String sang int ===
   Future<void> addUserToGroup(
       {required String userId, required int groupId}) async {
     await _performAction(() async {
       await _service.addUserToGroup(userId, groupId);
-      // === SỬA LỖI 3: Tải lại chỉ dữ liệu cần thiết thay vì toàn bộ hệ thống ===
       await loadMembersForGroup(groupId, forceReload: true);
     });
   }
 
-  // === SỬA LỖI 1: Thay đổi kiểu dữ liệu của groupId từ String sang int ===
   Future<void> removeUserFromGroup(
       {required String userId, required int groupId}) async {
     await _performAction(() async {
       await _service.removeUserFromGroup(userId, groupId);
-      // === SỬA LỖI 3: Tải lại chỉ dữ liệu cần thiết ===
       await loadMembersForGroup(groupId, forceReload: true);
     });
   }
 
-  // === SỬA LỖI 1: Thay đổi kiểu dữ liệu của groupId từ String sang int ===
-  // Thêm tham số forceReload để buộc tải lại dữ liệu khi cần (sau khi thêm/xóa thành viên)
   Future<void> loadMembersForGroup(int groupId,
       {bool forceReload = false}) async {
-    // Nếu đã có dữ liệu và không bị buộc tải lại, thì không làm gì cả
     if (groupMembers.containsKey(groupId) && !forceReload) return;
 
     loadingGroups.add(groupId);
@@ -91,7 +75,7 @@ class SystemController extends BaseController {
       groupMembers[groupId] = members;
     } catch (e) {
       debugPrint('Lỗi khi tải thành viên cho nhóm $groupId: $e');
-      groupMembers[groupId] = []; // Gán danh sách rỗng nếu có lỗi
+      groupMembers[groupId] = [];
     } finally {
       loadingGroups.remove(groupId);
       notifyListeners();

--- a/lib/Model/group_model.dart
+++ b/lib/Model/group_model.dart
@@ -1,6 +1,4 @@
-// Path: lib/Model/group_model.dart
-
-import 'package:equatable/equatable.dart'; // Thêm equatable để tốt hơn (tùy chọn)
+import 'package:equatable/equatable.dart';
 
 class Group extends Equatable {
   final int id;

--- a/lib/Model/user_model.dart
+++ b/lib/Model/user_model.dart
@@ -12,12 +12,11 @@ class User {
   final String? userName;
   final String? fullName;
 
-  // SỬA ĐỔI 2: Bỏ 'required' cho các trường nullable
   User({
     required this.id,
     required this.email,
-    this.userName, // Bỏ required
-    this.fullName, // Bỏ required
+    this.userName,
+    this.fullName,
     required this.role,
     required this.createdAt,
     required this.updatedAt,
@@ -28,7 +27,6 @@ class User {
     return User(
       id: json['id'] as String? ?? '',
       email: json['email'] as String? ?? 'no-email@example.com',
-      // SỬA ĐỔI 3: Đảm bảo role không bao giờ null trong model
       role: json['role'] as String? ?? 'staff',
       userName: json['user_name'] as String?,
       fullName: json['full_name'] as String?,
@@ -43,15 +41,11 @@ class User {
 
   ///chuyen sang json de tao CRUD
   Map<String, dynamic> toJson() {
-    // SỬA ĐỔI 1 (QUAN TRỌNG NHẤT): Sử dụng snake_case để gửi dữ liệu lên Supabase
     return {
-      // 'id' thường không cần gửi khi cập nhật, nhưng để đây cũng không sao
-      // 'email' và 'role' cũng có thể được cập nhật ở đây
       'user_name': userName,
       'full_name': fullName,
       'email': email,
       'role': role,
-      // created_at và updated_at thường do CSDL tự quản lý, không cần gửi lên
     };
   }
 

--- a/lib/core/exception/error_app.dart
+++ b/lib/core/exception/error_app.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+
 import '../services/file_service.dart';
 
+/// xu ly ngoai le khi khoi tao app
 class ErrorApp extends StatelessWidget {
   final Object error;
 
@@ -34,7 +36,8 @@ class ErrorApp extends StatelessWidget {
                       Text(
                         'Nội dung file lỗi:\n$fileContent',
                         textAlign: TextAlign.center,
-                        style: const TextStyle(fontSize: 14, color: Colors.grey),
+                        style:
+                            const TextStyle(fontSize: 14, color: Colors.grey),
                       ),
                     ],
                   ),

--- a/lib/core/services/owner/owner_note_service.dart
+++ b/lib/core/services/owner/owner_note_service.dart
@@ -3,14 +3,15 @@ import 'package:extractorapplication/core/services/db_help.dart';
 
 import '../../../Model/note_model.dart';
 
+///Lop service note bao gom cac phuong thuc crud tren bang note
+///lop giao tiep voi db ma khong can thong qua controller
+///giup tach biet hoan toan voi controller de xu ly logic
 class OwnerNoteService {
   final DatabaseService db;
   OwnerNoteService(this.db);
 
-  /// Creates a new note record in the database.
   Future<Note> createNote(Map<String, dynamic> noteData) async {
     try {
-      // Giả sử db.insert trả về một Map của bản ghi vừa được tạo
       final responseData = await db.insert('notes', noteData);
       return Note.fromJson(responseData);
     } catch (e) {
@@ -18,7 +19,6 @@ class OwnerNoteService {
     }
   }
 
-  /// Fetches all notes from the database.
   Future<List<Note>> getAllNotes() async {
     try {
       final response = await db.getAll('notes');
@@ -28,31 +28,17 @@ class OwnerNoteService {
     }
   }
 
-  // ================== BƯỚC 1: THÊM HÀM `updateNote` ==================
-  /// Updates an existing note in the database.
-  ///
-  /// - `note`: Đối tượng Note chứa thông tin mới.
-  ///           Hàm `toJson()` của nó sẽ được dùng để lấy dữ liệu cập nhật.
   Future<Note> updateNote(Note note) async {
     try {
-      // Giả sử hàm `db.update` nhận vào (tên bảng, id của bản ghi, dữ liệu Map để cập nhật).
-      // Hàm `note.toJson()` sẽ chuyển đổi đối tượng Note thành một Map<String, dynamic>
-      // với các khóa `snake_case` khớp với tên cột trong CSDL.
       final responseData = await db.update('notes', note.id, note.toJson());
-
-      // Supabase thường trả về bản ghi đã được cập nhật,
-      // chúng ta chuyển nó lại thành đối tượng Note.
       return Note.fromJson(responseData);
     } catch (e) {
       throw ServerException('Error updating note: $e');
     }
   }
 
-  // ================== BƯỚC 2: THÊM HÀM `deleteNote` ==================
-  /// Deletes a note from the database by its ID.
   Future<void> deleteNote(int noteId) async {
     try {
-      // Giả sử hàm `db.delete` nhận vào (tên bảng, id của bản ghi cần xóa).
       await db.delete('notes', noteId);
     } catch (e) {
       throw ServerException('Error deleting note: $e');

--- a/lib/core/utils/constants.dart
+++ b/lib/core/utils/constants.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 
+/// Quan ly cac appicons cung apptext mac dinh ma khong can phai goi lai nhieu lan
 class AppText {
   static const String appTitle = 'Quản lý chi tiêu';
   static const String welcomeMessage = 'Chào mừng bạn đến với ứng dụng';
-  static const String errorNetwork = 'Không thể kết nối tới máy chủ. Vui lòng thử lại';
+  static const String errorNetwork =
+      'Không thể kết nối tới máy chủ. Vui lòng thử lại';
 }
 
 class AppIcons {

--- a/lib/core/utils/provider.dart
+++ b/lib/core/utils/provider.dart
@@ -1,16 +1,13 @@
-// utils/provider.dart
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:provider/single_child_widget.dart';
 
-// Import Controllers
 import '../../Controller/auth_controller.dart';
 import '../../Controller/owner/financial_controller.dart';
 import '../../Controller/owner/note_management_controller.dart';
 import '../../Controller/owner/owner_dashboard_controller.dart';
 import '../../Controller/owner/system_controller.dart';
 import '../../Controller/owner/user_management_controller.dart';
-// Import Services
 import '../services/auth_service.dart';
 import '../services/db_help.dart';
 import '../services/owner/owner_financial_service.dart';
@@ -19,24 +16,15 @@ import '../services/owner/owner_system_service.dart';
 import '../services/owner/owner_user_service.dart';
 import '../services/owner/system_service.dart';
 
-/// Cung cap cac service va controller cho cac view
+/// noi dieu huong cac trang thay cho viec goi trong file
+/// giam thieu thoi gian lap trinh cungx nhu tang su nhat quan trong phat trien ung dung
 class AppProvider {
   static List<SingleChildWidget> providers = [
-    // #########################################################################
-    // ## CÁC SERVICE CỐT LÕI (Không phụ thuộc vào service khác)
-    // #########################################################################
     Provider(create: (_) => DatabaseService()),
     Provider(create: (_) => AuthService()),
-
-    // #########################################################################
-    // ## CÁC SERVICE NGHIỆP VỤ (Phụ thuộc vào Service cốt lõi)
-    // #########################################################################
     Provider(
         create: (context) =>
             OwnerFinancialService(context.read<DatabaseService>())),
-    Provider(
-        create: (context) =>
-            RevenueReportService(context.read<DatabaseService>())),
     Provider(
         create: (context) => OwnerUserService(context.read<DatabaseService>())),
     Provider(
@@ -46,16 +34,8 @@ class AppProvider {
             OwnerSystemService(context.read<DatabaseService>())),
     Provider(
         create: (context) => OwnerNoteService(context.read<DatabaseService>())),
-
-    // #########################################################################
-    // ## CÁC CONTROLLER (Phụ thuộc vào Services)
-    // #########################################################################
     ChangeNotifierProvider(
       create: (context) => AuthController(context.read<AuthService>()),
-    ),
-    ChangeNotifierProvider(
-      create: (context) =>
-          RevenueReportController(context.read<RevenueReportService>()),
     ),
     ChangeNotifierProvider(
       create: (context) =>
@@ -65,19 +45,14 @@ class AppProvider {
       create: (context) =>
           NoteManagementController(context.read<OwnerNoteService>()),
     ),
-
-    // ================== THAY ĐỔI DUY NHẤT NẰM Ở ĐÂY ==================
     ChangeNotifierProvider(
       create: (context) => OwnerDashboardController(
         context.read<OwnerUserService>(),
         context.read<OwnerFinancialService>(),
         context.read<OwnerSystemService>(),
-        // Thêm service còn thiếu để controller có thể lấy dữ liệu ghi chú
         context.read<OwnerNoteService>(),
       ),
     ),
-    // ====================================================================
-
     ChangeNotifierProvider(
       create: (context) =>
           UserManagementController(context.read<OwnerUserService>()),

--- a/lib/core/utils/validators.dart
+++ b/lib/core/utils/validators.dart
@@ -1,3 +1,5 @@
+///noi kiem tra ngoai le truoc khi dang nhap
+///dam bao cac truong nhap thong tin hop le
 class Validators {
   static String? validateEmail(String? value) {
     if (value == null || value.isEmpty) return 'Vui lòng nhập email';

--- a/lib/routes/app_route.dart
+++ b/lib/routes/app_route.dart
@@ -1,3 +1,5 @@
+///noi luu tru cac duong dan
+///tao su nhat quan khi goi duong dan trong app
 class AppRoutes {
   static const String login = '/login';
   static const String register = '/register';

--- a/lib/routes/role_router.dart
+++ b/lib/routes/role_router.dart
@@ -1,13 +1,19 @@
 import 'app_route.dart';
 
+///luu tru cac route mac dinh phan quyen nguoi dung
 class RoleRouter {
   static String getRouteByRole(String role) {
     switch (role) {
-      case 'owner': return AppRoutes.ownerNavigationView;
-      case 'kitchen': return '/kitchen-dashboard';
-      case 'manager': return '/manager-dashboard';
-      case 'staff': return '/staff-dashboard';
-      default: return '/login';
+      case 'owner':
+        return AppRoutes.ownerNavigationView;
+      case 'kitchen':
+        return '/kitchen-dashboard';
+      case 'manager':
+        return '/manager-dashboard';
+      case 'staff':
+        return '/staff-dashboard';
+      default:
+        return '/login';
     }
   }
 }

--- a/lib/routes/route_generator.dart
+++ b/lib/routes/route_generator.dart
@@ -17,6 +17,8 @@ import '../views/owner/user_management/user_list_view.dart';
 import '../views/shared/splash_screen.dart';
 import 'app_route.dart';
 
+///luu tru cac route trong app
+///cac route duoc gom thanh cac nhom de tao su nhat quan
 class RouteGenerator {
   static Route<dynamic> generateRoute(RouteSettings settings) {
     switch (settings.name) {

--- a/lib/views/owner/add_note_view.dart
+++ b/lib/views/owner/add_note_view.dart
@@ -1,7 +1,7 @@
 import 'package:extractorapplication/Controller/owner/note_management_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:supabase_flutter/supabase_flutter.dart'; // Correctly added import
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 class AddNoteView extends StatefulWidget {
   const AddNoteView({super.key});
@@ -38,8 +38,6 @@ class _AddNoteViewState extends State<AddNoteView> {
       return;
     }
 
-    // Simplified data payload to only what the user has entered.
-    // Let the database handle defaults for category, priority, etc.
     final noteData = {
       'user_id': userId,
       'title': _titleController.text,

--- a/lib/views/owner/dashboard/owner_dashboard_view.dart
+++ b/lib/views/owner/dashboard/owner_dashboard_view.dart
@@ -24,10 +24,8 @@ class _OwnerDashboardViewState extends State<OwnerDashboardView> {
   void initState() {
     super.initState();
     // Gọi hàm tải dữ liệu một lần duy nhất khi widget được khởi tạo.
-    // Sử dụng context.read() bên trong initState.
     final controller = context.read<OwnerDashboardController>();
     if (controller.shouldLoadData) {
-      // Dùng addPostFrameCallback để đảm bảo việc gọi không xảy ra trong lúc build.
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) {
           controller.loadDashboardData();
@@ -38,21 +36,16 @@ class _OwnerDashboardViewState extends State<OwnerDashboardView> {
 
   @override
   Widget build(BuildContext context) {
-    // Dùng context.watch() trong hàm build để lắng nghe các thay đổi từ controller.
     final controller = context.watch<OwnerDashboardController>();
 
     return Scaffold(
-      // SỬA ĐỔI 2: Cải thiện logic hiển thị trạng thái loading.
-      // Chỉ hiển thị loading toàn màn hình khi chưa có dữ liệu gì.
       body: (controller.isLoading && controller.recentNotes.isEmpty)
           ? const LoadingIndicator(
               fullscreen: true, message: 'Đang tải dữ liệu...')
           : RefreshIndicator(
-              onRefresh:
-                  controller.loadDashboardData, // Cho phép kéo để làm mới
+              onRefresh: controller.loadDashboardData,
               child: SingleChildScrollView(
-                physics:
-                    const AlwaysScrollableScrollPhysics(), // Luôn cho phép cuộn để RefreshIndicator hoạt động
+                physics: const AlwaysScrollableScrollPhysics(),
                 padding: const EdgeInsets.all(16),
                 child: Column(
                   children: [
@@ -62,11 +55,6 @@ class _OwnerDashboardViewState extends State<OwnerDashboardView> {
                       systemHealth: controller.systemHealth,
                     ),
                     const SizedBox(height: 20),
-
-                    // SỬA ĐỔI 3: Cập nhật cách gọi widget hiển thị ghi chú.
-                    // Tên widget là `RecentNotesView`.
-                    // Tham số là `notes` (không phải `activities`).
-                    // Nguồn dữ liệu là `controller.recentNotes` (không phải `controller.recentActivities`).
                     RecentNotesView(notes: controller.recentNotes),
                   ],
                 ),

--- a/lib/views/owner/edit_note.dart
+++ b/lib/views/owner/edit_note.dart
@@ -7,7 +7,6 @@ import '../../../../Controller/owner/note_management_controller.dart';
 import '../../../../Model/note_model.dart';
 
 class EditNoteView extends StatefulWidget {
-  // Widget này nhận vào đối tượng `Note` cần được chỉnh sửa.
   final Note note;
 
   const EditNoteView({super.key, required this.note});
@@ -19,13 +18,9 @@ class EditNoteView extends StatefulWidget {
 class _EditNoteViewState extends State<EditNoteView> {
   final _formKey = GlobalKey<FormState>();
 
-  // Khai báo các TextEditingController để quản lý dữ liệu trên form.
   late final TextEditingController _titleController;
   late final TextEditingController _contentController;
-  // Bạn có thể thêm các controller cho category, priority nếu muốn chúng cũng có thể được sửa.
 
-  // `initState` được gọi một lần khi widget được tạo.
-  // Chúng ta dùng nó để điền dữ liệu có sẵn của `note` vào các controller.
   @override
   void initState() {
     super.initState();
@@ -33,8 +28,6 @@ class _EditNoteViewState extends State<EditNoteView> {
     _contentController = TextEditingController(text: widget.note.content);
   }
 
-  // `dispose` được gọi khi widget bị hủy.
-  // Rất quan trọng để giải phóng bộ nhớ cho các controller.
   @override
   void dispose() {
     _titleController.dispose();
@@ -42,38 +35,49 @@ class _EditNoteViewState extends State<EditNoteView> {
     super.dispose();
   }
 
-  /// Hàm này được gọi khi người dùng nhấn nút "Lưu Thay Đổi".
   void _submitChanges() async {
-    // 1. Kiểm tra xem form có hợp lệ không.
     if (_formKey.currentState?.validate() != true) {
       return;
     }
 
-    // 2. Lấy controller từ Provider.
     final controller = context.read<NoteManagementController>();
 
-    // 3. Tạo một đối tượng `Note` mới với các thông tin đã được cập nhật từ form.
-    // Sử dụng `copyWith` để giữ lại các trường không thay đổi như `id`, `userId`, `createdAt`,...
     final updatedNote = widget.note.copyWith(
       title: _titleController.text.trim(),
       content: _contentController.text.trim(),
-      // Gán lại updatedAt thành thời gian hiện tại.
       updatedAt: DateTime.now(),
     );
 
-    // 4. Gọi hàm `updateNote` từ controller.
     final success = await controller.updateNote(updatedNote);
+
     if (!mounted) return;
+
+    if (success) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Cập nhật ghi chú thành công!'),
+          backgroundColor: Colors.green,
+        ),
+      );
+      Navigator.of(context).pop();
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+              'Lỗi: ${controller.errorMessage ?? "Không thể cập nhật ghi chú."}'),
+          backgroundColor: Colors.red,
+        ),
+      );
+    }
   }
 
   @override
   Widget build(BuildContext context) {
-    // Lắng nghe trạng thái `isLoading` từ controller để vô hiệu hóa nút bấm khi cần.
     final isLoading = context.watch<NoteManagementController>().isLoading;
 
     return Scaffold(
       appBar: AppBar(
-        title: Text('Sửa Ghi Chú'),
+        title: const Text('Sửa Ghi Chú'),
       ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
@@ -89,7 +93,6 @@ class _EditNoteViewState extends State<EditNoteView> {
                   prefixIcon: Icon(Icons.title),
                 ),
                 validator: (value) {
-                  // Mặc dù title có thể null, ta vẫn có thể yêu cầu người dùng không để trống khi sửa.
                   if (value == null || value.trim().isEmpty) {
                     return 'Vui lòng nhập tiêu đề';
                   }
@@ -103,10 +106,9 @@ class _EditNoteViewState extends State<EditNoteView> {
                   labelText: 'Nội dung',
                   border: OutlineInputBorder(),
                   prefixIcon: Icon(Icons.text_fields),
-                  alignLabelWithHint:
-                      true, // Căn chỉnh label lên trên khi có nhiều dòng.
+                  alignLabelWithHint: true,
                 ),
-                maxLines: 8, // Cho phép nhập nhiều dòng hơn cho nội dung.
+                maxLines: 8,
                 validator: (value) {
                   if (value == null || value.trim().isEmpty) {
                     return 'Vui lòng nhập nội dung';
@@ -119,11 +121,10 @@ class _EditNoteViewState extends State<EditNoteView> {
                 onPressed: isLoading ? null : _submitChanges,
                 style: ElevatedButton.styleFrom(
                   padding: const EdgeInsets.symmetric(vertical: 16),
-                  backgroundColor:
-                      Colors.blue, // Màu sắc cho hành động cập nhật.
+                  backgroundColor: Colors.blue,
                 ),
                 icon: isLoading
-                    ? Container() // Ẩn icon khi đang loading
+                    ? Container()
                     : const Icon(Icons.save_as_outlined),
                 label: isLoading
                     ? const CircularProgressIndicator(color: Colors.white)

--- a/lib/views/owner/financial/add_revenue_view.dart
+++ b/lib/views/owner/financial/add_revenue_view.dart
@@ -18,19 +18,13 @@ class _AddRevenueViewState extends State<AddRevenueView> {
   final _amountController = TextEditingController();
   final _descriptionController = TextEditingController();
   DateTime _selectedDate = DateTime.now();
-
-  // Biến state để lưu các giá trị được chọn từ form
   String? _selectedCategory;
-  // BƯỚC 1: THÊM BIẾN ĐỂ LƯU TRỮ GROUP ĐÃ CHỌN
-  int? _selectedGroupId; // ID của group là kiểu int
+  int? _selectedGroupId;
 
   @override
   void initState() {
     super.initState();
-    // Ngay khi màn hình được tạo, yêu cầu SystemController tải danh sách nhóm.
-    // Dùng addPostFrameCallback để đảm bảo việc gọi không xảy ra trong lúc build.
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      // Đảm bảo SystemController đã được cung cấp ở cây widget cha.
       context.read<SystemController>().loadSystemOverview();
     });
   }
@@ -57,7 +51,6 @@ class _AddRevenueViewState extends State<AddRevenueView> {
   }
 
   void _saveRevenue() async {
-    // Kích hoạt validation và kiểm tra form
     if (_formKey.currentState?.validate() != true) {
       return;
     }
@@ -75,20 +68,15 @@ class _AddRevenueViewState extends State<AddRevenueView> {
       return;
     }
 
-    // BƯỚC 2: CẬP NHẬT DỮ LIỆU GỬI ĐI, THÊM 'group_id' VÀO MAP
     final expenseData = {
       'user_id': userId,
       'amount': double.parse(_amountController.text),
       'description': _descriptionController.text,
       'category': _selectedCategory,
-      'group_id': _selectedGroupId, // << Thêm giá trị group_id đã chọn
+      'group_id': _selectedGroupId,
       'created_at': _selectedDate.toIso8601String(),
     };
-
-    // Gọi hàm `addRevenue` và kiểm tra kết quả trả về
     final success = await controller.addRevenue(expenseData);
-
-    // Chỉ thực hiện các hành động tiếp theo nếu widget vẫn còn trên cây UI
     if (!mounted) return;
   }
 
@@ -132,8 +120,6 @@ class _AddRevenueViewState extends State<AddRevenueView> {
                 },
               ),
               const SizedBox(height: 16),
-
-              // BƯỚC 3: THÊM WIDGET DROPDOWN ĐỂ CHỌN NHÓM
               DropdownButtonFormField<int>(
                 value: _selectedGroupId,
                 decoration: const InputDecoration(
@@ -142,14 +128,12 @@ class _AddRevenueViewState extends State<AddRevenueView> {
                   prefixIcon: Icon(Icons.group_work_outlined),
                 ),
                 hint: const Text('Chọn nhóm liên quan'),
-                // Dữ liệu được lấy từ SystemController,
-                // hiển thị loading nếu chưa có dữ liệu nhóm
                 items: systemController.isLoading
                     ? []
                     : systemController.groups.map((Group group) {
                         return DropdownMenuItem<int>(
-                          value: group.id, // Giá trị là ID của nhóm (int)
-                          child: Text(group.name), // Hiển thị là tên nhóm
+                          value: group.id,
+                          child: Text(group.name),
                         );
                       }).toList(),
                 onChanged: (value) {
@@ -157,14 +141,10 @@ class _AddRevenueViewState extends State<AddRevenueView> {
                     _selectedGroupId = value;
                   });
                 },
-                // Bắt buộc người dùng phải chọn một nhóm
                 validator: (value) =>
                     value == null ? 'Vui lòng chọn một nhóm' : null,
               ),
-
               const SizedBox(height: 16),
-
-              // Widget dropdown để chọn danh mục (đã có từ trước)
               DropdownButtonFormField<String>(
                 value: _selectedCategory,
                 decoration: const InputDecoration(
@@ -190,9 +170,7 @@ class _AddRevenueViewState extends State<AddRevenueView> {
                     ? 'Vui lòng chọn một danh mục'
                     : null,
               ),
-
               const SizedBox(height: 16),
-
               TextFormField(
                 controller: _descriptionController,
                 decoration: const InputDecoration(
@@ -201,10 +179,8 @@ class _AddRevenueViewState extends State<AddRevenueView> {
                   hintText: 'Nhập mô tả cho khoản thu',
                 ),
                 maxLines: 3,
-                // Ghi chú là tùy chọn, không cần validator
               ),
               const SizedBox(height: 16),
-
               Row(
                 children: [
                   Expanded(

--- a/lib/views/owner/financial/revenue_report_view.dart
+++ b/lib/views/owner/financial/revenue_report_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+
 import '../../../Controller/owner/financial_controller.dart';
 import '../../../core/utils/date_formatter.dart';
 
@@ -10,19 +11,14 @@ class RevenueReportView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // 1. Lấy và lắng nghe RevenueReportController
     final controller = context.watch<RevenueReportController>();
 
-    // 2. Gọi hàm tải dữ liệu nếu cần
     if (controller.shouldLoadData) {
-      // Gọi hàm đúng của controller này
       controller.loadRevenueReport();
     }
-
-    // 3. Xây dựng UI dựa trên trạng thái của RevenueReportController
     return Scaffold(
       appBar: AppBar(title: const Text('📈 Báo cáo doanh thu theo tháng')),
-      body: _buildBody(controller), // Tách UI ra một hàm riêng cho sạch sẽ
+      body: _buildBody(controller),
     );
   }
 

--- a/lib/views/owner/owner_navigation.dart
+++ b/lib/views/owner/owner_navigation.dart
@@ -19,10 +19,8 @@ class OwnerNavigationShell extends StatefulWidget {
 }
 
 class _OwnerNavigationShellState extends State<OwnerNavigationShell> {
-  // Quản lý state bằng index thay vì String
   int _currentIndex = 0;
 
-  // Tối ưu: Chỉ tạo danh sách các trang một lần
   final List<Widget> _pages = [
     const OwnerDashboardView(),
     const UserListView(),
@@ -38,8 +36,6 @@ class _OwnerNavigationShellState extends State<OwnerNavigationShell> {
   ];
 
   void handleLogout() {
-    // Chỉ cần lấy controller và gọi logout.
-    // StreamBuilder sẽ tự động điều hướng.
     Provider.of<AuthController>(context, listen: false).logout();
   }
 
@@ -65,12 +61,10 @@ class _OwnerNavigationShellState extends State<OwnerNavigationShell> {
         ],
         elevation: 2,
       ),
-      // ✅ Tối ưu: Dùng IndexedStack để giữ trạng thái các trang
       body: IndexedStack(
         index: _currentIndex,
         children: _pages,
       ),
-      // Add the FloatingActionButton
       floatingActionButton: const CreationSpeedDial(),
       bottomNavigationBar: BottomNavigationBar(
         backgroundColor: AppPallete.backgroundColor,

--- a/lib/views/owner/system/system_list_view.dart
+++ b/lib/views/owner/system/system_list_view.dart
@@ -4,7 +4,6 @@ import 'package:provider/provider.dart';
 import '../../../Controller/owner/system_controller.dart';
 import '../../shared/loading_indicator.dart';
 
-// Chuyển thành StatefulWidget để quản lý việc tải dữ liệu ban đầu tốt hơn
 class OwnerSystemOverviewView extends StatefulWidget {
   const OwnerSystemOverviewView({super.key});
 
@@ -17,12 +16,9 @@ class _OwnerSystemOverviewViewState extends State<OwnerSystemOverviewView> {
   @override
   void initState() {
     super.initState();
-    // Sử dụng context.read() trong initState để gọi hàm một lần mà không gây ra vòng lặp build
     final controller = context.read<SystemController>();
     if (controller.shouldLoadData) {
-      // Dùng addPostFrameCallback để đảm bảo context đã sẵn sàng
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        // Chỉ gọi hàm load nếu cần, tránh gọi lại không cần thiết
         if (mounted) {
           controller.loadSystemOverview();
         }
@@ -32,7 +28,6 @@ class _OwnerSystemOverviewViewState extends State<OwnerSystemOverviewView> {
 
   @override
   Widget build(BuildContext context) {
-    // Dùng context.watch() trong build để lắng nghe thay đổi và cập nhật UI
     final controller = context.watch<SystemController>();
     return Scaffold(
       body: _buildBody(context, controller),
@@ -58,7 +53,6 @@ class _OwnerSystemOverviewViewState extends State<OwnerSystemOverviewView> {
         itemCount: controller.groups.length,
         itemBuilder: (context, index) {
           final group = controller.groups[index];
-          // group.id bây giờ là int, cần đảm bảo controller.groupMembers dùng Map<int, ...>
           final members = controller.groupMembers[group.id];
           final isLoadingMembers = controller.loadingGroups.contains(group.id);
 
@@ -66,12 +60,10 @@ class _OwnerSystemOverviewViewState extends State<OwnerSystemOverviewView> {
             margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
             clipBehavior: Clip.antiAlias,
             child: ExpansionTile(
-              // Bỏ các toán tử `??` vì `id` và `name` không thể null
               title: Text('🧭 ${group.name}'),
               subtitle: Text('ID: ${group.id}'),
               onExpansionChanged: (isExpanding) {
                 if (isExpanding && members == null) {
-                  // Chỉ load nếu chưa có dữ liệu
                   controller.loadMembersForGroup(group.id);
                 }
               },
@@ -91,7 +83,6 @@ class _OwnerSystemOverviewViewState extends State<OwnerSystemOverviewView> {
                     ...members.map((member) => ListTile(
                           leading: const Icon(Icons.person_outline,
                               color: Colors.blueGrey),
-                          // Giữ lại `??` ở đây vì thông tin user có thể null
                           title: Text(member.fullName ??
                               member.userName ??
                               'Người dùng không tên'),

--- a/lib/views/owner/user_management/widgets/edit_user.dart
+++ b/lib/views/owner/user_management/widgets/edit_user.dart
@@ -1,6 +1,7 @@
 import 'package:extractorapplication/Model/user_model.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+
 import '../../../../Controller/owner/user_management_controller.dart';
 
 ///chinh sua du lieu nguoi dung theo id
@@ -16,13 +17,11 @@ class EditUser extends StatefulWidget {
 
 class _EditUserState extends State<EditUser> {
   final _formKey = GlobalKey<FormState>();
-  //khai bao controller nhung chua gan gia tri
   late final TextEditingController fullNameController;
   late final TextEditingController emailController;
   late final TextEditingController usernameController;
   late String selectedRole;
 
-  //dien du lieu cu vao form
   @override
   void initState() {
     super.initState();
@@ -45,8 +44,6 @@ class _EditUserState extends State<EditUser> {
       return;
     }
     final controller = context.read<UserManagementController>();
-    //tao mot doi tuong user moi voi du lieu cap nhat
-    //giu lai id va cac truong khong thay doi
     final updatedUser = widget.user.copyWith(
       fullName: fullNameController.text.trim(),
       email: emailController.text.trim(),
@@ -57,7 +54,10 @@ class _EditUserState extends State<EditUser> {
     await controller.updateUser(updatedUser);
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Sửa thông tin thành công'), backgroundColor: Colors.green,),
+        const SnackBar(
+          content: Text('Sửa thông tin thành công'),
+          backgroundColor: Colors.green,
+        ),
       );
       Navigator.of(context).pop();
     }
@@ -69,7 +69,8 @@ class _EditUserState extends State<EditUser> {
     final isLoading = context.watch<UserManagementController>().isLoading;
 
     return Scaffold(
-      appBar: AppBar(title: Text('Sửa thông tin ${widget.user.fullName ?? ''}')),
+      appBar:
+          AppBar(title: Text('Sửa thông tin ${widget.user.fullName ?? ''}')),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Form(
@@ -105,10 +106,14 @@ class _EditUserState extends State<EditUser> {
                 value: selectedRole,
                 decoration: const InputDecoration(labelText: 'Vai trò'),
                 items: const [
-                  DropdownMenuItem(value: 'staff', child: Text('Nhân viên (Staff)')),
-                  DropdownMenuItem(value: 'admin', child: Text('Quản trị viên (Admin)')),
-                  DropdownMenuItem(value: 'manager', child: Text('Quản lý (Manager)')),
-                  DropdownMenuItem(value: 'owner', child: Text('Chủ sở hữu (Owner)')),
+                  DropdownMenuItem(
+                      value: 'staff', child: Text('Nhân viên (Staff)')),
+                  DropdownMenuItem(
+                      value: 'admin', child: Text('Quản trị viên (Admin)')),
+                  DropdownMenuItem(
+                      value: 'manager', child: Text('Quản lý (Manager)')),
+                  DropdownMenuItem(
+                      value: 'owner', child: Text('Chủ sở hữu (Owner)')),
                 ],
                 onChanged: (value) {
                   if (value != null) {

--- a/lib/views/shared/loading_indicator.dart
+++ b/lib/views/shared/loading_indicator.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../core/theme/app_theme.dart';
 
+///man hinh hien thi loading thay cho viec nguoi dung phai ngoi cho
 class LoadingIndicator extends StatelessWidget {
   final double size;
   final Color? color;

--- a/lib/views/shared/splash_screen.dart
+++ b/lib/views/shared/splash_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+///man hinh loading cho viec ung dung dang load du lieu
 class SplashScreen extends StatelessWidget {
   const SplashScreen({super.key});
 
@@ -7,14 +8,11 @@ class SplashScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return const Scaffold(
       body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            CircularProgressIndicator(),
-            SizedBox(height: 16),
-            Text('Loading...'),
-          ]
-        ), // Simple loading indicator
+        child: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
+          CircularProgressIndicator(),
+          SizedBox(height: 16),
+          Text('Loading...'),
+        ]), // Simple loading indicator
       ),
     );
   }

--- a/lib/views/shared/widgets/creation_speed_dial.dart
+++ b/lib/views/shared/widgets/creation_speed_dial.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+///view hien thi bang con trong trang chu
+///lay thong tin so luong nguoi dung dang online, daonh thu va kiem tra he thong online hay offline
 class CreationSpeedDial extends StatefulWidget {
   const CreationSpeedDial({super.key});
 


### PR DESCRIPTION
This commit introduces several refactorings and improvements across the application, focusing on code cleanup, enhancing UI logic, and expanding functionality.

- **Refactor Code and Remove Redundancy:**
    - Removed a significant number of commented-out code blocks and unnecessary comments across multiple files, including `owner_dashboard_view.dart`, `system_list_view.dart`, `add_revenue_view.dart`, and `edit_note.dart`.
    - Simplified data loading logic in `initState` by removing `WidgetsBinding.instance.addPostFrameCallback` where it was not strictly necessary.
    - Added documentation comments (`///`) to clarify the purpose of widgets and services like `CreationSpeedDial`, `ErrorApp`, `OwnerNoteService`, and various route files.

- **Enhance Financial and Note Views:**
    - Updated the "Add Revenue" form (`add_revenue_view.dart`) to include a mandatory "Group" selection dropdown, allowing revenue to be associated with a specific group.
    - Implemented UI feedback in `edit_note.dart`, showing success or error `SnackBar` messages after attempting to update a note.
    - Cleaned up the `RevenueReportView` by removing redundant comments.

- **Improve Dashboard and System Views:**
    - In `OwnerDashboardController`, integrated `OwnerNoteService` to fetch and display recent notes instead of a placeholder list of activities.
    - Updated the `owner_dashboard_view.dart` to correctly display the list of recent notes fetched by the controller.
    - Corrected the `group_id` key in `SystemController` from `String` to `int` to match the data model, resolving potential runtime errors when managing group members.

- **Minor Model and Provider Updates:**
    - In `user_model.dart`, removed unnecessary `required` keywords for nullable fields in the constructor.
    - Simplified provider setup in `provider.dart` by removing unused service registrations (`RevenueReportService`).