### PR TITLE
test: Refactor `widget_test.dart` for consistency and best practices

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,15 +5,14 @@
 // gestures. You can also use WidgetTester to find child widgets in the widgets
 // tree, read text, and verify that the values of widgets properties are correct.
 
+import 'package:extractorapplication/main.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import 'package:extractorapplication/main.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(MyApp());
+    await tester.pumpWidget(const MyApp());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
- Reorder imports to place project-specific imports before Flutter framework imports.
- Add the `const` keyword to the `MyApp` instantiation to improve performance and adhere to linting standards.