### PR TITLE
build: Update Android SDK versions and cleanup test file

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -15,28 +15,23 @@ subprojects {
     project.layout.buildDirectory.value(newSubprojectBuildDir)
 }
 
-subprojects {
-    project.evaluationDependsOn(":app")
-}
-
 tasks.register<Delete>("clean") {
     delete(rootProject.layout.buildDirectory)
 }
 
-// Cấu hình đồng bộ compileSdk cho tất cả subprojects
 subprojects {
-    // Sử dụng afterEvaluate nhưng thay đổi cách truy cập extension để tránh lỗi "too late"
-    afterEvaluate {
-        val androidExtension = project.extensions.findByName("android")
-        if (androidExtension is com.android.build.gradle.BaseExtension) {
-            androidExtension.apply {
-                compileSdkVersion(34)
-                buildToolsVersion("34.0.0")
+    plugins.withType<com.android.build.gradle.api.AndroidBasePlugin> {
+        configure<com.android.build.gradle.BaseExtension> {
+            compileSdkVersion(34)
+            buildToolsVersion("34.0.0")
 
-                // Xử lý lỗi namespace cho các plugin cũ như app_links
-                if (namespace == null) {
-                    namespace = "com.extractor.application.${project.name.replace("-", "_")}"
-                }
+            if (namespace == null) {
+                namespace = "com.extractor.application.${project.name.replace("-", "_")}"
+            }
+
+            defaultConfig {
+                minSdkVersion(21)
+                targetSdkVersion(34)
             }
         }
     }

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -5,20 +5,35 @@ allprojects {
     }
 }
 
-val newBuildDir: Directory =
-    rootProject.layout.buildDirectory
-        .dir("../../build")
-        .get()
+val newBuildDir: Directory = rootProject.layout.buildDirectory
+    .dir("../../build")
+    .get()
 rootProject.layout.buildDirectory.value(newBuildDir)
 
 subprojects {
     val newSubprojectBuildDir: Directory = newBuildDir.dir(project.name)
     project.layout.buildDirectory.value(newSubprojectBuildDir)
 }
-subprojects {
-    project.evaluationDependsOn(":app")
-}
+
 
 tasks.register<Delete>("clean") {
     delete(rootProject.layout.buildDirectory)
+}
+
+subprojects {
+    plugins.withType<com.android.build.gradle.api.AndroidBasePlugin> {
+        configure<com.android.build.gradle.BaseExtension> {
+            compileSdkVersion(34)
+            buildToolsVersion("34.0.0")
+
+            if (namespace == null) {
+                namespace = "com.extractor.application.${project.name.replace("-", "_")}"
+            }
+
+            defaultConfig {
+                minSdkVersion(21)
+                targetSdkVersion(34)
+            }
+        }
+    }
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -4,18 +4,11 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 void main() {
   testWidgets('Initial screen load test', (WidgetTester tester) async {
-    // Khởi tạo Supabase giả lập để tránh lỗi "You must initialize the supabase instance"
     await Supabase.initialize(
       url: 'https://placeholder-url.supabase.co',
       anonKey: 'placeholder-key',
     );
 
-    // Build ứng dụng của bạn
     await tester.pumpWidget(const MyApp());
-
-    // Vì ứng dụng của bạn bắt đầu bằng màn hình Login hoặc Splash
-    // chứ không phải Counter, bạn nên tìm một text có trong màn hình đầu tiên.
-    // Ví dụ: Tìm chữ "Đăng nhập" thay vì tìm số "0"
-    // expect(find.text('Đăng nhập'), findsOneWidget);
   });
 }


### PR DESCRIPTION
- Update `android/build.gradle.kts` to standardize subproject configurations, setting `compileSdkVersion` and `targetSdkVersion` to 34, and `minSdkVersion` to 21.
- Automatically generate namespaces for subprojects if not explicitly defined.
- Clean up comments in `test/widget_test.dart`.